### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # luckymoney
 一个旨在帮助手慢人士抢微信红包的android项目，实现了微信红包自动抢的功能，最低支持版本android4.4。实现原理是检测通知栏消息判断是否有红包，自动打开微信聊天列表，借助AccessibilityService去模拟人工点击，实现秒抢红包，手慢的人，你们有福了！！！
 
-##ScreenShot
+## ScreenShot
 
 ![Alt text](demo4.gif)&nbsp;


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
